### PR TITLE
Prevent Duplicate Likes/Dislikes on Recipes

### DIFF
--- a/src/main/java/data_access/InMemoryUserDataAccessObject.java
+++ b/src/main/java/data_access/InMemoryUserDataAccessObject.java
@@ -401,4 +401,24 @@ public class InMemoryUserDataAccessObject implements SignupUserDataAccessInterfa
         currentUser.addDislikedRecipe(recipeName);
     }
 
+    @Override
+    public void updateUserLikedRecipe(String recipeName) {
+        final User currentUser = get(getCurrentUsername());
+        // Replace the old entry with the new password
+        users.put(currentUser.getName(), currentUser);
+        deleteFileFromFileIo();
+        writeUsersToFile(users);
+        uploadFileToFileIo();
+    }
+
+    @Override
+    public void updateUserDislikedRecipe(String recipeName) {
+        final User currentUser = get(getCurrentUsername());
+        // Replace the old entry with the new password
+        users.put(currentUser.getName(), currentUser);
+        deleteFileFromFileIo();
+        writeUsersToFile(users);
+        uploadFileToFileIo();
+    }
+
 }

--- a/src/main/java/use_case/like_and_dislike_a_recipe/UserLikeAndDislikeDataAccessInterface.java
+++ b/src/main/java/use_case/like_and_dislike_a_recipe/UserLikeAndDislikeDataAccessInterface.java
@@ -11,4 +11,8 @@ public interface UserLikeAndDislikeDataAccessInterface {
     boolean hasUserDislikedRecipe(String recipeName);
 
     void addDislikedRecipe(String recipeName);
+
+    void updateUserLikedRecipe(String recipeName);
+
+    void updateUserDislikedRecipe(String recipeName);
 }

--- a/src/main/java/use_case/like_and_dislike_a_recipe/dislike/DislikeRecipeInteractor.java
+++ b/src/main/java/use_case/like_and_dislike_a_recipe/dislike/DislikeRecipeInteractor.java
@@ -47,6 +47,7 @@ public class DislikeRecipeInteractor implements LikeAndDislikeRecipeInputBoundar
 
             // Add the dislike to user data
             dislikeRecipeDataAccessObject.addDislikedRecipe(recipeName);
+            dislikeRecipeDataAccessObject.updateUserDislikedRecipe(recipeName);
 
             final int updatedDislikeNumber = theRecipe.getDislikeNumber();
             final DislikeRecipeOutputData dislikeRecipeOutputData = new DislikeRecipeOutputData(recipeName, updatedDislikeNumber);

--- a/src/main/java/use_case/like_and_dislike_a_recipe/like/LikeRecipeInteractor.java
+++ b/src/main/java/use_case/like_and_dislike_a_recipe/like/LikeRecipeInteractor.java
@@ -47,6 +47,7 @@ public class LikeRecipeInteractor implements LikeAndDislikeRecipeInputBoundary {
 
             // Add the like to user data
             likeRecipeDataAccessObject.addLikedRecipe(recipeName);
+            likeRecipeDataAccessObject.updateUserLikedRecipe(recipeName);
 
             final int updatedLikeNumber = theRecipe.getLikeNumber();
             final LikeRecipeOutputData likeRecipeOutputData = new LikeRecipeOutputData(recipeName, updatedLikeNumber);


### PR DESCRIPTION
- Updated logic to ensure users cannot like a recipe they have already liked.
- Implemented similar restriction for disliking a recipe they have already disliked.